### PR TITLE
Fixed an issue where AND was appended to the where clause when it was…

### DIFF
--- a/Sitecore.XDB.ReshardingTool/Services/ReadService.cs
+++ b/Sitecore.XDB.ReshardingTool/Services/ReadService.cs
@@ -63,7 +63,7 @@ namespace Sitecore.XDB.ReshardingTool.Services
 
             if (lastSubmitted != null)
             {
-                if (where != null)
+                if (!string.IsNullOrEmpty(where))
                 {
                     where += $"AND {fieldPrefix}{orderFieldName} > '{lastSubmitted:D}'";
                 }


### PR DESCRIPTION
There is an situation where the Where clause isn't null, but an empty string. This causes exceptions due to an invalid query being generated.

This occurs on the following line in ReshardingTool.cs
`  await ProcessEnttity<InteractionFacet>(_contactMap, "[xdb_collection].[InteractionFacets]", nameof(InteractionFacet.InteractionId), token, interactionsJoin + interactionsWhere, "f");
`

`interactionsJoin `and `interactionsWhere `are both null, however concatenating strings (even tough they are null) results in an empty string.
