### PR TITLE
Added multithreading and extra logging

### DIFF
--- a/Sitecore.XDB.ReshardingTool/Program.cs
+++ b/Sitecore.XDB.ReshardingTool/Program.cs
@@ -38,7 +38,9 @@ namespace Sitecore.XDB.ReshardingTool
                     int.Parse(appSettings["ConnectionTimeout"]),
                     int.Parse(appSettings["BatchSize"]),
                     int.Parse(appSettings["RetryCount"]),
-                    int.Parse(appSettings["RetryDelay"])
+                    int.Parse(appSettings["RetryDelay"]),
+                    ParseNullableInt(appSettings["ReadThreads"]),
+                    ParseNullableInt(appSettings["WriteThreadsPerSourceShard"])
                 );
 
                 Console.WriteLine("Resharding is initialized, commands: -start, -stop, -quit/-q");
@@ -148,6 +150,16 @@ namespace Sitecore.XDB.ReshardingTool
             Log.CloseAndFlush();
             Console.WriteLine("Press any key to exit...");
             Console.ReadLine();
+        }
+
+        private static int? ParseNullableInt(string value)
+        {
+            if (int.TryParse(value, out var result))
+            {
+                return result;
+            }
+
+            return null;
         }
     }
 }

--- a/Sitecore.XDB.ReshardingTool/Sitecore.XDB.ReshardingTool.csproj
+++ b/Sitecore.XDB.ReshardingTool/Sitecore.XDB.ReshardingTool.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="AsyncEnumerator" Version="4.0.2" />
     <PackageReference Include="Microsoft.Azure.SqlDatabase.ElasticScale.Client" Version="2.3.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="Serilog" Version="2.8.0" />

--- a/Sitecore.XDB.ReshardingTool/appsettings.json
+++ b/Sitecore.XDB.ReshardingTool/appsettings.json
@@ -8,7 +8,9 @@
     "DeviceProfileIdShardMap": "DeviceProfileIdShardMap",
     "ContactIdentifiersIndexShardMap": "ContactIdentifiersIndexShardMap",
     "InteractionsFromDate": "2019-09-01",
-    "InteractionsFilterByEventDefinitions": [ "2a65acc5-9851-40dd-851b-23f7a6c53092", "0fd3ef44-6c4a-40ce-8f97-6197bd9c61f2" ]
+    "InteractionsFilterByEventDefinitions": [ "2a65acc5-9851-40dd-851b-23f7a6c53092", "0fd3ef44-6c4a-40ce-8f97-6197bd9c61f2" ],
+    "ReadThreads": "",
+    "WriteThreadsPerSourceShard":  "" 
   },
   "ConnectionStrings": {
     "collection.source": "user id=sa;password=Password1!;data source=.\\SQLENTERPRISE;Initial Catalog=test1_Xdb.Collection.ShardMapManager",


### PR DESCRIPTION
Added multithreading for reading from the shards and writing to the new shards, and also added some extra logging to see the progress and performance. I've removed the count(*) even from the debug mode, as this does a full table scan and even for testing is extremly slow. If you want me to put this back in, please let me know.

More information:
As each shard has unique databases to write to, we can do this simultaneously without having to worry about the table locks.

For example, when migrating from two shards to four shards, the following scenario will occur:
old-shard-0 -> new-shard-0
old-shard-0 -> new-shard-1
old-shard-1 -> new-shard-2
old-shard-2 -> new-shard-3

In the initial application, only one source and one target shard were used at the same time. Now it uses all shards at the same time.
This change reduced the time needed from +-9 hours to +- 3 hours in my specific scenario.