### PR TITLE
Fix resharding of ContactIdentifiersIndex

### DIFF
--- a/Sitecore.XDB.ReshardingTool/Models/ContactIdentifiersIndex.cs
+++ b/Sitecore.XDB.ReshardingTool/Models/ContactIdentifiersIndex.cs
@@ -14,7 +14,7 @@ namespace Sitecore.XDB.ReshardingTool.Models
         public Guid Version { get; set; }
         public byte[] GetKey()
         {
-            return PartitionKeyGenerator.Generate(ContactId);
+            return PartitionKeyGenerator.Generate(Identifier);
         }
         public SqlGuid GetOrderFieldValue()
         {

--- a/Sitecore.XDB.ReshardingTool/Models/Interaction.cs
+++ b/Sitecore.XDB.ReshardingTool/Models/Interaction.cs
@@ -24,7 +24,7 @@ namespace Sitecore.XDB.ReshardingTool.Models
         public double Percentile { get; set; }
         public byte[] GetKey()
         {
-            return PartitionKeyGenerator.Generate(InteractionId);
+            return PartitionKeyGenerator.Generate(ContactId);
         }
 
         public SqlGuid GetOrderFieldValue()

--- a/Sitecore.XDB.ReshardingTool/Models/InteractionFacet.cs
+++ b/Sitecore.XDB.ReshardingTool/Models/InteractionFacet.cs
@@ -14,7 +14,7 @@ namespace Sitecore.XDB.ReshardingTool.Models
         public string FacetData { get; set; }
         public byte[] GetKey()
         {
-            return PartitionKeyGenerator.Generate(InteractionId);
+            return PartitionKeyGenerator.Generate(ContactId);
         }
 
         public SqlGuid GetOrderFieldValue()


### PR DESCRIPTION
Hi,

I've used the Resharding tool to reshard my databases, however afterwards Sitecore was unable to resolve a part of the contacts based on their identifiers. This is because the ContactIdentifiersIndex isn't sharded correctly, as this is done based on their ContactId. The ContactIdentifiersIndex should be sharded based on their Identifier.

Regards,